### PR TITLE
modify tf broadcast node and OMPL typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
     tf
     )
 ## OPEN MOTION PLANNING LIBRARY
-find_package(OMPL REQUIRED)
+find_package(ompl REQUIRED)
 
 if(NOT OMPL_FOUND)
     message(AUTHOR_WARNING,"Open Motion Planning Library not found")

--- a/launch/manual.launch
+++ b/launch/manual.launch
@@ -1,7 +1,7 @@
 <launch>
  <!-- Turn on hybrid_astar node -->
  <node name="hybrid_astar" pkg="hybrid_astar" type="hybrid_astar" output="screen"/> 
- <node name="tf_broadcaster" pkg="hybrid_astar" type="tf_broadcaster" />
+ <node name="tf_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 0 /map /path 100" />
  <node name="map_server" pkg="map_server" type="map_server" args="$(find hybrid_astar)/maps/map.yaml" />
  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find hybrid_astar)/launch/config.rviz" />
 </launch>


### PR DESCRIPTION
1. When using `catkin_make` to compile this repo, maybe occur the followiing error:

```bash
By not providing “FindOMPL.cmake” in CMAKE_MODULE_PATH this project has
asked CMake to find a package configuration file provided by “OMPL”, but
CMake did not find one.
Could not find a package configuration file provided by “OMPL” with any of
the following names:
OMPLConfig.cmake
ompl-config.cmake
```

This error can be solved by replace **OMPL** with **ompl** in the CMakeLists.txt (line 14).

2. After you launch the `manual.launch`, the `tf_broadcaster` would be missed within `hybrid_astar` package, i.e. this repo. I delete `<node name="tf_broadcaster" pkg="hybrid_astar" type="tf_broadcaster" />` and add `<node name="tf_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 0 /map /path 100" />` to `manual.launch`, so that path which was calculated by this repo can be visualized in the rviz.